### PR TITLE
add userToken support #24

### DIFF
--- a/arcdps_uploader/Uploader.h
+++ b/arcdps_uploader/Uploader.h
@@ -18,6 +18,14 @@ struct StatusMessage
 	int log_id;
 };
 
+struct UserToken
+{
+	int id;
+	std::string value;
+	bool disabled;
+	char value_buf[128];
+};
+
 struct Webhook
 {
 	int id;
@@ -50,7 +58,8 @@ class Uploader
 
 	std::deque<int> upload_queue;
 	std::vector<std::future<cpr::Response>> ft_uploads;
-
+	std::vector<UserToken> userTokens;
+	UserToken userToken;
 	std::vector<Webhook> webhooks;
 	std::mutex wh_mutex;
 	std::deque<int> wh_queue;


### PR DESCRIPTION
Store the dps.report userToken response and persist it in the config.
Send the stored userToken with every upload.

Add the userToken to the configuratoin UI.
This allows setting, resetting and disabling the userToken.

At the moment only one userToken can be stored but the current
implementation could be extended easily to support multiple tokens
and the ability to switch between them.