### PR TITLE
Additional user configuration for formatted log message

### DIFF
--- a/arcdps_uploader/Settings.cpp
+++ b/arcdps_uploader/Settings.cpp
@@ -15,6 +15,7 @@ void Settings::load() {
         wvw_detailed_enabled = ini.GetBoolValue(
             INI_SECTION_SETTINGS, INI_WVW_DETAILED_SETTING, false);
         msg_format = ini.GetValue(INI_SECTION_SETTINGS, INI_MSG_FORMAT, "@1 - \\n*@2*\\n\\n");
+        recent_minutes = ini.GetLongValue(INI_SECTION_SETTINGS, INI_RECENT_MINUTES, 150);
         gw2bot_enabled =
             ini.GetBoolValue(INI_SECTION_SETTINGS, INI_GW2BOT_ENABLED, false);
 
@@ -53,6 +54,7 @@ void Settings::save() {
     ini.SetBoolValue(INI_SECTION_SETTINGS, INI_WVW_DETAILED_SETTING,
                      wvw_detailed_enabled);
     ini.SetValue(INI_SECTION_SETTINGS, INI_MSG_FORMAT, msg_format.c_str());
+    ini.SetLongValue(INI_SECTION_SETTINGS, INI_RECENT_MINUTES, recent_minutes);
     ini.SetBoolValue(INI_SECTION_SETTINGS, INI_GW2BOT_ENABLED, gw2bot_enabled);
     ini.SetValue(INI_SECTION_SETTINGS, INI_GW2BOT_KEY, gw2bot_key.c_str());
     ini.SetBoolValue(INI_SECTION_SETTINGS, INI_GW2BOT_SUCCESS_ONLY,

--- a/arcdps_uploader/Settings.cpp
+++ b/arcdps_uploader/Settings.cpp
@@ -14,7 +14,7 @@ void Settings::load() {
         LOG_F(INFO, "Loaded INI file");
         wvw_detailed_enabled = ini.GetBoolValue(
             INI_SECTION_SETTINGS, INI_WVW_DETAILED_SETTING, false);
-
+        msg_format = ini.GetValue(INI_SECTION_SETTINGS, INI_MSG_FORMAT, "@1 - \\n*@2*\\n\\n");
         gw2bot_enabled =
             ini.GetBoolValue(INI_SECTION_SETTINGS, INI_GW2BOT_ENABLED, false);
 
@@ -52,6 +52,7 @@ void Settings::load() {
 void Settings::save() {
     ini.SetBoolValue(INI_SECTION_SETTINGS, INI_WVW_DETAILED_SETTING,
                      wvw_detailed_enabled);
+    ini.SetValue(INI_SECTION_SETTINGS, INI_MSG_FORMAT, msg_format.c_str());
     ini.SetBoolValue(INI_SECTION_SETTINGS, INI_GW2BOT_ENABLED, gw2bot_enabled);
     ini.SetValue(INI_SECTION_SETTINGS, INI_GW2BOT_KEY, gw2bot_key.c_str());
     ini.SetBoolValue(INI_SECTION_SETTINGS, INI_GW2BOT_SUCCESS_ONLY,

--- a/arcdps_uploader/Settings.h
+++ b/arcdps_uploader/Settings.h
@@ -31,6 +31,7 @@ struct Settings
 
 	bool wvw_detailed_enabled;
 	std::string msg_format;
+	int recent_minutes;
 	bool gw2bot_enabled;
 	std::string gw2bot_key;
 	bool gw2bot_success_only;
@@ -44,6 +45,7 @@ struct Settings
 inline constexpr char* INI_SECTION_SETTINGS = "Settings";
 inline constexpr char* INI_WVW_DETAILED_SETTING = "WvW_Detailed";
 inline constexpr char* INI_MSG_FORMAT = "Msg_Format";
+inline constexpr char* INI_RECENT_MINUTES = "Recent_Minutes";
 inline constexpr char* INI_GW2BOT_ENABLED = "GW2Bot_Enabled";
 inline constexpr char* INI_GW2BOT_KEY = "GW2Bot_Key";
 inline constexpr char* INI_GW2BOT_SUCCESS_ONLY = "GW2Bot_Success_Only";

--- a/arcdps_uploader/Settings.h
+++ b/arcdps_uploader/Settings.h
@@ -30,6 +30,7 @@ struct Settings
 	CSimpleIniA ini;
 
 	bool wvw_detailed_enabled;
+	std::string msg_format;
 	bool gw2bot_enabled;
 	std::string gw2bot_key;
 	bool gw2bot_success_only;
@@ -42,6 +43,7 @@ struct Settings
 
 inline constexpr char* INI_SECTION_SETTINGS = "Settings";
 inline constexpr char* INI_WVW_DETAILED_SETTING = "WvW_Detailed";
+inline constexpr char* INI_MSG_FORMAT = "Msg_Format";
 inline constexpr char* INI_GW2BOT_ENABLED = "GW2Bot_Enabled";
 inline constexpr char* INI_GW2BOT_KEY = "GW2Bot_Key";
 inline constexpr char* INI_GW2BOT_SUCCESS_ONLY = "GW2Bot_Success_Only";

--- a/arcdps_uploader/Uploader.cpp
+++ b/arcdps_uploader/Uploader.cpp
@@ -307,6 +307,25 @@ void Uploader::imgui_draw_logs() {
 
     ImGui::SameLine();
 
+    if (ImGui::Button("Copy & Format Selected")) {
+        std::time_t now = std::time(nullptr);
+        std::tm* local = std::localtime(&now);
+        char buf[64];
+        strftime(buf, 64, "__**%b %d %Y**__\n\n", local);
+
+        std::string msg(buf);
+
+        for (int i = 0; i < logs.size(); ++i) {
+            if (selected[i]) {
+                const Log& s = logs.at(i);
+                msg += s.boss_name + " - " + "\n*" + s.permalink + "*\n\n";
+            }
+        }
+        ImGui::SetClipboardText(msg.c_str());
+    }
+
+    ImGui::SameLine();
+
     if (ImGui::Button("Copy & Format Recent Clears")) {
         std::time_t now = std::time(nullptr);
         std::tm* local = std::localtime(&now);

--- a/arcdps_uploader/Uploader.cpp
+++ b/arcdps_uploader/Uploader.cpp
@@ -1349,6 +1349,5 @@ std::string Uploader::format_msg(Log log) {
 
     msg = std::regex_replace(msg, std::regex("@1"), log.boss_name);
     msg = std::regex_replace(msg, std::regex("@2"), log.permalink);
-    msg = std::regex_replace(msg, std::regex("@3"), std::to_string(log.boss_id));
     return msg;
 }

--- a/arcdps_uploader/Uploader.cpp
+++ b/arcdps_uploader/Uploader.cpp
@@ -337,7 +337,7 @@ void Uploader::imgui_draw_logs() {
         std::chrono::system_clock::time_point current =
             std::chrono::system_clock::now();
         std::chrono::system_clock::time_point past =
-            current - std::chrono::minutes(150);
+            current - std::chrono::minutes(settings.recent_minutes);
         for (int i = 0; i < logs.size(); ++i) {
             const Log& s = logs.at(i);
             if (s.uploaded && s.success) {
@@ -714,6 +714,10 @@ void Uploader::imgui_draw_options() {
                     "\\n: new line");
                 ImGui::EndTooltip();
             }
+
+            ImGui::PushItemWidth(ImGui::GetContentRegionAvailWidth() * 0.25f);
+            ImGui::InputInt("# of minutes back for recent clears", &settings.recent_minutes);
+            ImGui::PopItemWidth();
 
             ImGui::TreePop();
         }

--- a/arcdps_uploader/Uploader.h
+++ b/arcdps_uploader/Uploader.h
@@ -88,6 +88,8 @@ class Uploader
 
 	void queue_status_message(const std::string& msg, int log_id = -1);
 	void queue_status_message(const StatusMessage& status);
+
+	std::string format_msg(Log log);
 public:
 	bool is_open;
 	bool in_combat;


### PR DESCRIPTION
1. Added `Copy & Format Selected` button
* Takes users selected logs and formats them according to the provided message format

2. Added configuration for formatted log output used by `Copy & Format Selected` and `Copy & Format Recent Clears`
* These two functions now follow the output message format specified in the `Options > Other` section
* Format allows for parameter specification as follows:
```
@1: boss_name
@2: report permalink
\n: newline
```
* Default value matches the current implementation: `@1 - \n*@2*\n\n`

3. Allow user to specify number of minutes used by `Copy & Format Recent Clears`.
* Default value matches current implementation: `150`

![uploader_sample](https://user-images.githubusercontent.com/1359826/232317719-500aff72-3e90-4491-bef7-1d0b513bf9f1.PNG)