### PR TITLE
Fix uploading Undefined logs to all webhooks

### DIFF
--- a/arcdps_uploader/Uploader.cpp
+++ b/arcdps_uploader/Uploader.cpp
@@ -964,6 +964,8 @@ void Uploader::check_webhooks(int log_id) {
                 process = false;
             if (category == Revtc::BossCategory::WVW && !wh.wvw)
                 process = false;
+            if (category == Revtc::BossCategory::UNKNOWN)
+                process = false;
 
             if (wh.filter.size() > 5) {
                 std::vector<std::string> accounts;


### PR DESCRIPTION
This happened to me when doing OLC CM for example, which is why I also created a pull request to update revtc.
The log simply posted to all (2) webhooks that I had, even though the other one was defined to only post raid logs.